### PR TITLE
Allow users to define a TTL on issues to avoid repeat notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ the following configurations to your `lita_config.rb`.
 config.handlers.jira_issues.url = 'http://jira.local'
 config.handlers.jira_issues.username = ENV['JIRA_USER'] || 'user'
 config.handlers.jira_issues.password = ENV['JIRA_PASSWORD'] || 'password'
-config.handlers.jira_issues.key_expiration = 120 #optional
+config.handlers.jira_issues.issue_ttl = 0 #optional
 ```
 
 As in the example above, you can always use environment variables for sensitive
@@ -43,7 +43,13 @@ configuration parameter
 config.handlers.jira_issues.ignore = [ 'Jira', 'Github' ]
 ```
 
-Optionally you can set a timer for how long sleep prior to posting an issue to chat again.  This is accomplished by setting an expiring key in Redis. That timeout is govered by the `config.handlers.jira_issues.key_expiration` config.  The default is 0 seconds which equates to disabled.
+Optionally you can set a timer for how long sleep prior to posting an issue to chat again.  This is accomplished by setting an expiring key in Redis. That timeout is govered by the following config
+
+```ruby
+config.handlers.jira_issues.issue_ttl=120
+```
+
+The default for this config is 0 which serves to disables the feature entirely.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ configuration parameter
 config.handlers.jira_issues.ignore = [ 'Jira', 'Github' ]
 ```
 
-Optionally you can set a timer for how long sleep prior to posting an issue to chat again.  This is accomplished by setting an expiring key in Redis. That timeout is govered by the following config
+Optionally you can set a timer for how long to sleep prior to posting an issue to chat again.  This is accomplished by setting an expiring key in Redis. That timeout is governed by the following config
 
 ```ruby
 config.handlers.jira_issues.issue_ttl = 120

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ config.handlers.jira_issues.ignore = [ 'Jira', 'Github' ]
 Optionally you can set a timer for how long sleep prior to posting an issue to chat again.  This is accomplished by setting an expiring key in Redis. That timeout is govered by the following config
 
 ```ruby
-config.handlers.jira_issues.issue_ttl=120
+config.handlers.jira_issues.issue_ttl = 120
 ```
 
 The default for this config is 0 which serves to disables the feature entirely.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ the following configurations to your `lita_config.rb`.
 config.handlers.jira_issues.url = 'http://jira.local'
 config.handlers.jira_issues.username = ENV['JIRA_USER'] || 'user'
 config.handlers.jira_issues.password = ENV['JIRA_PASSWORD'] || 'password'
+config.handlers.jira_issues.key_expiration = 120 #optional
 ```
 
 As in the example above, you can always use environment variables for sensitive
@@ -41,6 +42,8 @@ configuration parameter
 ```ruby
 config.handlers.jira_issues.ignore = [ 'Jira', 'Github' ]
 ```
+
+Optionally you can set a timer for how long sleep prior to posting an issue to chat again.  This is accomplished by setting an expiring key in Redis. That timeout is govered by the `config.handlers.jira_issues.key_expiration` config.  The default is 0 seconds which equates to disabled.
 
 ## Usage
 

--- a/lib/lita/handlers/jira_issues.rb
+++ b/lib/lita/handlers/jira_issues.rb
@@ -9,7 +9,7 @@ module Lita
       config :username, required: true, type: String
       config :password, required: true, type: String
       config :ignore, default: [], type: Array
-      config :key_expiration, default: 120, type: Integer
+      config :issue_ttl, default: 0, type: Integer
 
       route /[a-zA-Z]+-\d+/, :jira_message, help: {
         "KEY-123" => "Replies with information about the given JIRA key"
@@ -26,14 +26,14 @@ module Lita
       def handle_key(response, key)
         data = @jira.data_for_issue(key)
         return if data.empty?
-        unless config.key_expiration == 0
+        unless config.issue_ttl == 0
           current_ttl = redis.ttl(key).to_i
           if current_ttl > 0
             log.debug("Key expiration not met for #{key}, will not reprompt for #{current_ttl} seconds")
             return
           else
-            redis.setex(key, config.key_expiration, key)
-            log.debug("Setting expiring key in redis for JIRA issue: #{key}. Key is configured to expire in #{config.key_expiration} seconds")
+            redis.setex(key, config.issue_ttl, key)
+            log.debug("Setting expiring key in redis for JIRA issue: #{key}. Key is configured to expire in #{config.issue_ttl} seconds")
           end
         end
         issue = issue_details(data)

--- a/lita-jira-issues.gemspec
+++ b/lita-jira-issues.gemspec
@@ -22,4 +22,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", ">= 3.0.0"
   spec.add_development_dependency "simplecov"
   spec.add_development_dependency "coveralls"
+  spec.add_development_dependency "fakeredis"
 end

--- a/spec/lita/handlers/jira_issues_spec.rb
+++ b/spec/lita/handlers/jira_issues_spec.rb
@@ -7,7 +7,33 @@ describe Lita::Handlers::JiraIssues, lita_handler: true do
 
   describe 'Looking up keys' do
 
+    context 'Test silenced handler' do
+
+      let(:redis) { Redis::Namespace }
+
+      it 'should return false when issue ttl is set to 0, which is default' do
+        Lita.config.handlers.jira_issues.issue_ttl = 0
+        expect(Lita::Handlers::JiraIssues.new.silenced?("KEY-123")).to eql false
+      end
+
+      context 'configured ttl of 10 seconds' do
+        before(:each) { Lita.config.handlers.jira_issues.issue_ttl = 10 }
+
+        it 'should return true with redis ttl is 10' do
+          allow_any_instance_of(redis).to receive(:ttl).with('KEY-424').and_return("10")
+          expect(Lita::Handlers::JiraIssues.new.silenced?("KEY-424")).to eql true
+        end
+
+        it 'should return true for silenced when redis ttl is -2' do
+          allow_any_instance_of(redis).to receive(:ttl).with('KEY-424').and_return("-2")
+          expect(Lita::Handlers::JiraIssues.new.silenced?("KEY-424")).to eql false
+        end
+      end
+
+    end
+
     before(:each) do
+      Lita.test_mode = true
       Lita.config.handlers.jira_issues.url = 'http://jira.local'
       Lita.config.handlers.jira_issues.username = 'user'
       Lita.config.handlers.jira_issues.password = 'pass'

--- a/spec/lita/handlers/jira_issues_spec.rb
+++ b/spec/lita/handlers/jira_issues_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require 'spec_helper'
 
 describe Lita::Handlers::JiraIssues, lita_handler: true do
 
@@ -13,20 +13,20 @@ describe Lita::Handlers::JiraIssues, lita_handler: true do
 
       it 'should return false when issue ttl is set to 0, which is default' do
         Lita.config.handlers.jira_issues.issue_ttl = 0
-        expect(Lita::Handlers::JiraIssues.new.silenced?("KEY-123")).to eql false
+        expect(Lita::Handlers::JiraIssues.new.silenced?('KEY-123')).to eql false
       end
 
       context 'configured ttl of 10 seconds' do
         before(:each) { Lita.config.handlers.jira_issues.issue_ttl = 10 }
 
         it 'should return true with redis ttl is 10' do
-          allow_any_instance_of(redis).to receive(:ttl).with('KEY-424').and_return("10")
-          expect(Lita::Handlers::JiraIssues.new.silenced?("KEY-424")).to eql true
+          allow_any_instance_of(redis).to receive(:ttl).with('KEY-424').and_return('10')
+          expect(Lita::Handlers::JiraIssues.new.silenced?('KEY-424')).to eql true
         end
 
         it 'should return true for silenced when redis ttl is -2' do
-          allow_any_instance_of(redis).to receive(:ttl).with('KEY-424').and_return("-2")
-          expect(Lita::Handlers::JiraIssues.new.silenced?("KEY-424")).to eql false
+          allow_any_instance_of(redis).to receive(:ttl).with('KEY-424').and_return('-2')
+          expect(Lita::Handlers::JiraIssues.new.silenced?('KEY-424')).to eql false
         end
       end
 
@@ -113,8 +113,8 @@ http://jira.local/browse/PROJ-9872
         }
       })
 
-      bob = Lita::User.create(123, name: "Bob Smith")
-      fred = Lita::User.create(123, name: "Fred Smith")
+      bob = Lita::User.create(123, name: 'Bob Smith')
+      fred = Lita::User.create(123, name: 'Fred Smith')
 
       send_message('Some message KEY-424 more text', as: bob)
       expect(replies.last).not_to match('KEY-424')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,5 +8,5 @@ SimpleCov.start { add_filter "/spec/" }
 
 require "lita-jira-issues"
 require "lita/rspec"
-
+require "fakeredis/rspec"
 Lita.version_3_compatibility_mode = false


### PR DESCRIPTION
Sometimes an issue will be mentioned several times in quick succession and the bot posting a ticket status in the midst of the conversation can be distracting.  This PR provides a configurable TTL for issues which helps avoid this scenario.  We use Redis expiring keys to accomplish and the default is set to 0 seconds.   My intent w/ that default was to avoid changing the expectation for anyone who unwittingly upgrades 