### PR TITLE
Configurable response template

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ config.handlers.jira_issues.url = 'http://jira.local'
 config.handlers.jira_issues.username = ENV['JIRA_USER'] || 'user'
 config.handlers.jira_issues.password = ENV['JIRA_PASSWORD'] || 'password'
 config.handlers.jira_issues.issue_ttl = 0 #optional
-config.handlers.jira_issues.format = '[%I] %S::%s'  #optional
+config.handlers.jira_issues.format = '[%I] %S::%t'  #optional
 ```
 
 As in the example above, you can always use environment variables for sensitive

--- a/README.md
+++ b/README.md
@@ -64,6 +64,11 @@ Status: %{status}, assigned to %{assignee}, rep. by %{reporter}, fixVersion: %{v
 %{link}
 ```
 
+The response to referenced JIRA tickets are left up to you, but shortened formats are now available like:
+
+```
+[%{KEY}] %{PRIORITY}/%{Summary} - %{STATUS}\n%{link}
+```
 
 Pattern  | Substitution
 ---------|-------------
@@ -75,6 +80,7 @@ reporter | Reporter
 version  | Version
 priority | Priority
 link     | URL to JIRA issue page
+url      | Same as %{link}
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -56,11 +56,19 @@ You can now change the displayed format using keyword expansion. The following t
 
 Each keyword can take one of 3 forms. If the keyword is specified in all CAPS, then the resulting text will be in all caps (i.e. 'KEY' => 'ABC-123'). If the keyword has an initial capital letter, then resulting text will be proper case (i.e. 'Key' => 'Abc-123'). Finally if the keyword is all lower case, then the resulting text will be the native format that the text was received in. 
 
+There is also a conditional syntax that can be use should the keyword not return a value. The conditional syntax roughly approximates a ternary operator found in several programming languages such as C, Java and Perl with slight modificaiton to make pattern matching easier.
+
+```
+#(%{assignee}?Assigned to %{assignee}|UNASSIGNED)
+```
+
+In the above example, the start of the conditional syntax starts with the `#(` and is completed with the closing `)`. The first part (what is preceding the question mark) is what is evaluated. If the evaluation is not an empty string (i.e. ''), then the conditional syntax is replaced with the text between the question and the pipe (`|`) symbol. If the evaluation does return an empty string (i.e. assignee is not set), then the text following the pipe symbol will replace the conditional syntax. As one would expect, keyword substitutions occur within the conditional syntax. 
+
 By default the format is set to the original text displayed by the lita-jira-issues module. 
 
 ```
 [%{KEY}] %{summary}
-Status: %{status}, assigned to %{assignee}, rep. by %{reporter}, fixVersion: %{version}, priority: %{priority}
+Status: %{status}, #(%{assignee}?assigned to %{assignee}|unassigned), rep. by %{reporter}, fixVersion: %{version}#(%{priority}?, priority: %{priority}|)
 %{link}
 ```
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ By default the format is set to the original text displayed by the lita-jira-iss
 
 ```
 [%{KEY}] %{summary}
-Status: %{status}, #(%{assignee}?assigned to %{assignee}|unassigned), rep. by %{reporter}, fixVersion: %{version}#(%{priority}?, priority: %{priority}|)
+Status: %{status}, #(%{assignee}?assigned to %{assignee}|unassigned), rep. by %{reporter}, fixVersion: #(%{version}?%{version}|NONE)#(%{priority}?, priority: %{priority}|)
 %{link}
 ```
 

--- a/README.md
+++ b/README.md
@@ -52,28 +52,29 @@ config.handlers.jira_issues.issue_ttl = 120
 
 The default for this config is 0 which serves to disables the feature entirely.
 
-You can now change the displayed format. Using the following table of patterns, one can now set the format configuration setting to a string that will be displayed when a JIRA ticket is referenced. By default the format is set to the original text displayed by the lita-jira-issues module. 
+You can now change the displayed format using keyword expansion. The following table of keywords can be used to create the response when a JIRA ticket is referenced. Each keyword needs to be enclosed in %{} just as the Ruby `%` operator requires.  
+
+Each keyword can take one of 3 forms. If the keyword is specified in all CAPS, then the resulting text will be in all caps (i.e. 'KEY' => 'ABC-123'). If the keyword has an initial capital letter, then resulting text will be proper case (i.e. 'Key' => 'Abc-123'). Finally if the keyword is all lower case, then the resulting text will be the native format that the text was received in. 
+
+By default the format is set to the original text displayed by the lita-jira-issues module. 
 
 ```
-[%I] %t
-Status: %s, assigned to %a, rep. by %r, fixVersion: %v, priority: %P
-%U
+[%{KEY}] %{summary}
+Status: %{status}, assigned to %{assignee}, rep. by %{reporter}, fixVersion: %{version}, priority: %{priority}
+%{link}
 ```
 
 
-Pattern | Substitution
---------|-------------
-%I      | Issue number (uppercase)
-%i      | Issue number (lowercase)
-%S      | Issue status (uppercase)
-%s      | Issue status (lowercase)
-%t      | Issue summary
-%a      | Assignee
-%r      | Reporter
-%v      | Version
-%P      | Priority (uppercase)
-%p      | Priority (lowercase)
-%U      | URL to JIRA issue page
+Pattern  | Substitution
+---------|-------------
+key      | Issue number 
+status   | Issue status
+summary  | Issue summary
+assignee | Assignee
+reporter | Reporter
+version  | Version
+priority | Priority
+link     | URL to JIRA issue page
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ config.handlers.jira_issues.url = 'http://jira.local'
 config.handlers.jira_issues.username = ENV['JIRA_USER'] || 'user'
 config.handlers.jira_issues.password = ENV['JIRA_PASSWORD'] || 'password'
 config.handlers.jira_issues.issue_ttl = 0 #optional
+config.handlers.jira_issues.format = '[%I] %S::%s'  #optional
 ```
 
 As in the example above, you can always use environment variables for sensitive
@@ -50,6 +51,29 @@ config.handlers.jira_issues.issue_ttl = 120
 ```
 
 The default for this config is 0 which serves to disables the feature entirely.
+
+You can now change the displayed format. Using the following table of patterns, one can now set the format configuration setting to a string that will be displayed when a JIRA ticket is referenced. By default the format is set to the original text displayed by the lita-jira-issues module. 
+
+```
+[%I] %t
+Status: %s, assigned to %a, rep. by %r, fixVersion: %v, priority: %P
+%U
+```
+
+
+Pattern | Substitution
+--------|-------------
+%I      | Issue number (uppercase)
+%i      | Issue number (lowercase)
+%S      | Issue status (uppercase)
+%s      | Issue status (lowercase)
+%t      | Issue summary
+%a      | Assignee
+%r      | Reporter
+%v      | Version
+%P      | Priority (uppercase)
+%p      | Priority (lowercase)
+%U      | URL to JIRA issue page
 
 ## Usage
 

--- a/lib/lita/handlers/jira_issues.rb
+++ b/lib/lita/handlers/jira_issues.rb
@@ -7,7 +7,7 @@ module Lita
 
       FORMAT = <<-FORMATTER
 [%{KEY}] %{summary}
-Status: %{status}, #(%{assignee}?assigned to %{assignee}|unassigned), rep. by %{reporter}, fixVersion: %{version}#(%{priority}?, priority: %{priority}|)
+Status: %{status}, #(%{assignee}?assigned to %{assignee}|unassigned), rep. by %{reporter}, fixVersion: #(%{version}?%{version}|NONE)#(%{priority}?, priority: %{priority}|)
 %{link}
 FORMATTER
 
@@ -93,7 +93,7 @@ FORMATTER
         if fix_versions and fix_versions.first
           fix_versions.first[:name]
         else
-          'NONE'
+          ''
         end
       end
 
@@ -101,7 +101,7 @@ FORMATTER
         if data[:priority]
           data[:priority][:name]
         else
-          ""
+          ''
         end
       end
 

--- a/lib/lita/handlers/jira_issues.rb
+++ b/lib/lita/handlers/jira_issues.rb
@@ -38,7 +38,7 @@ module Lita
         data = data[:fields]
         
         # build out the response from the configured format
-        text = config.format
+        text = String.new(config.format)
         text.sub!('%I', key.upcase)
         text.sub!('%i', key.downcase)
         text.sub!('%S', status(data).upcase)

--- a/lib/lita/handlers/jira_issues.rb
+++ b/lib/lita/handlers/jira_issues.rb
@@ -7,7 +7,7 @@ module Lita
 
       FORMAT = <<-FORMATTER
 [%{KEY}] %{summary}
-Status: %{status}, assigned to %{assignee}, rep. by %{reporter}, fixVersion: %{version}, priority: %{priority}
+Status: %{status}, #(%{assignee}?assigned to %{assignee}|unassigned), rep. by %{reporter}, fixVersion: %{version}#(%{priority}?, priority: %{priority}|)
 %{link}
 FORMATTER
 
@@ -56,6 +56,16 @@ FORMATTER
           URL: issue_link(key), url: issue_link(key)
         }
         
+        # evaluate conditional syntax
+        text.gsub!(/#\(.*?\?.*?\|.*?\)/) do |cond_stmt|
+          vals = cond_stmt.match(/#\((?<value>.*?)\?(?<true_text>.*?)\|(?<false_text>.*?)\)/)
+          if vals[:value].empty?
+            vals[:false_text].gsub("\|", "|").gsub("\?", "?")
+          else
+            vals[:true_text].gsub("\|", "|").gsub("\?", "?")
+          end
+        end
+        
         return text
       end
 
@@ -71,7 +81,7 @@ FORMATTER
         if assigned_to = data[:assignee]
           return assigned_to[:displayName]
         end
-        'unassigned'
+        ''
       end
 
       def reporter(data)

--- a/lib/lita/handlers/jira_issues.rb
+++ b/lib/lita/handlers/jira_issues.rb
@@ -6,10 +6,10 @@ module Lita
     class JiraIssues < Handler
 
       FORMAT = <<-FORMATTER
-      [%{KEY}] %{summary}
-      Status: %{status}, assigned to %{assignee}, rep. by %{reporter}, fixVersion: %{version}, priority: %{priority}
-      %{link}
-      FORMATTER
+[%{KEY}] %{summary}
+Status: %{status}, assigned to %{assignee}, rep. by %{reporter}, fixVersion: %{version}, priority: %{priority}
+%{link}
+FORMATTER
 
       config :url, required: true, type: String
       config :username, required: true, type: String

--- a/lib/lita/handlers/jira_issues.rb
+++ b/lib/lita/handlers/jira_issues.rb
@@ -16,7 +16,7 @@ FORMATTER
       config :password, required: true, type: String
       config :ignore, default: [], type: Array
       config :issue_ttl, default: 0, type: Integer
-      config :format, default: FORMAT, type: String
+      config :format, default: FORMAT.chomp, type: String
       
 
       route /[a-zA-Z]+-\d+/, :jira_message, help: {

--- a/lib/lita/handlers/jira_issues.rb
+++ b/lib/lita/handlers/jira_issues.rb
@@ -52,7 +52,8 @@ module Lita
           STATUS: status(data).upcase, Status: status(data).capitalize, status: status(data),
           PRIORITY: priority(data).upcase, Priority: priority(data).capitalize, priority: priority(data),
           VERSION: fix_version(data).upcase, Version: fix_version(data).capitalize, version: fix_version(data),
-          LINK: issue_link(key), link: issue_link(key) 
+          LINK: issue_link(key), link: issue_link(key),
+          URL: issue_link(key), url: issue_link(key)
         }
         
         return text

--- a/spec/lita/handlers/jira_issues_spec.rb
+++ b/spec/lita/handlers/jira_issues_spec.rb
@@ -71,13 +71,13 @@ http://jira.local/browse/KEY-424
       send_message('Some PROJ-9872 message nEw-1 more text')
       expect(replies.pop).to eq(<<-EOS.chomp
 [NEW-1] New 1
-Status: Open, assigned to unassigned, rep. by User2, fixVersion: NONE, priority: High
+Status: Open, unassigned, rep. by User2, fixVersion: NONE, priority: High
 http://jira.local/browse/NEW-1
                                 EOS
                                )
       expect(replies.pop).to eq(<<-EOS.chomp
 [PROJ-9872] Too many bugs
-Status: Resolved, assigned to unassigned, rep. by User, fixVersion: NONE, priority: 
+Status: Resolved, unassigned, rep. by User, fixVersion: NONE
 http://jira.local/browse/PROJ-9872
                                 EOS
                                )

--- a/spec/lita/handlers/jira_issues_spec.rb
+++ b/spec/lita/handlers/jira_issues_spec.rb
@@ -71,13 +71,13 @@ http://jira.local/browse/KEY-424
       send_message('Some PROJ-9872 message nEw-1 more text')
       expect(replies.pop).to eq(<<-EOS.chomp
 [NEW-1] New 1
-Status: Open, unassigned, rep. by User2, fixVersion: NONE, priority: High
+Status: Open, assigned to unassigned, rep. by User2, fixVersion: NONE, priority: High
 http://jira.local/browse/NEW-1
                                 EOS
                                )
       expect(replies.pop).to eq(<<-EOS.chomp
 [PROJ-9872] Too many bugs
-Status: Resolved, unassigned, rep. by User, fixVersion: NONE
+Status: Resolved, assigned to unassigned, rep. by User, fixVersion: NONE, priority: 
 http://jira.local/browse/PROJ-9872
                                 EOS
                                )


### PR DESCRIPTION
I have added the ability to configure how lita-jira-issues responds to a reference to a JIRA ticket. This takes the form of a configuration entry that allows the implementer to specify the format of the response with the default being what lita-jira-issues has traditionally responded with. This change has been documented in the README.md. 
